### PR TITLE
Added option to enable PCRE for Linux git

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following attributes are platform-specific.
 * `node['git']['version']` - git version to install
 * `node['git']['url']` - URL to git tarball
 * `node['git']['checksum']` - tarball SHA256 checksum
+* `node['git']['use_pcre']` - if true, builds git with PCRE enabled
 
 Recipes
 =======

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,6 +34,7 @@ else
   default['git']['version'] = '1.9.5'
   default['git']['url'] = "https://nodeload.github.com/git/git/tar.gz/v#{node['git']['version']}"
   default['git']['checksum'] = '0f30984828d573da01d9f8e78210d5f4c56da1697fd6d278bad4cfa4c22ba271'
+  default['git']['use_pcre'] = false
 end
 
 default['git']['server']['base_path'] = '/srv/git'

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -29,13 +29,17 @@ when 'rhel'
   case node['platform_version'].to_i
   when 5
     pkgs = %w{ expat-devel gettext-devel curl-devel openssl-devel zlib-devel }
+    pkgs += %w{ libpcre3-dev } if node['git']['use_pcre']
   when 6, 7
     pkgs = %w{ expat-devel gettext-devel libcurl-devel openssl-devel perl-ExtUtils-MakeMaker zlib-devel }
+    pkgs += %w{ libpcre3-dev } if node['git']['use_pcre']
   else
     pkgs = %w{ expat-devel gettext-devel curl-devel openssl-devel perl-ExtUtils-MakeMaker zlib-devel } if node['platform'] == 'amazon'
+    pkgs += %w{ libpcre3-dev } if node['git']['use_pcre']
   end
 when 'debian'
   pkgs = %w{ libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev }
+  pkgs += %w{ libpcre3-dev } if node['git']['use_pcre']
 end
 
 pkgs.each do |pkg|
@@ -53,9 +57,11 @@ end
 # reduce line-noise-eyness
 execute "Extracting and Building Git #{node['git']['version']} from Source" do
   cwd Chef::Config['file_cache_path']
+  additional_make_params = ""
+  additional_make_params += "USE_LIBPCRE=1" if node['git']['use_pcre']
   command <<-COMMAND
     (mkdir git-#{node['git']['version']} && tar -zxf git-#{node['git']['version']}.tar.gz -C git-#{node['git']['version']} --strip-components 1)
-    (cd git-#{node['git']['version']} && make prefix=#{node['git']['prefix']} install)
+    (cd git-#{node['git']['version']} && make prefix=#{node['git']['prefix']} #{additional_make_params} install)
   COMMAND
   not_if "git --version | grep #{node['git']['version']}"
 end


### PR DESCRIPTION
Some complex filtering requires Perl regexp usage. Added option for Linux (source) git, if its true, then git will be built with libpcre support. It's false by default, so old behavior remains.