### PR TITLE
Allow Chef 12 metadata attributes to be compatible with Chef 11

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -29,8 +29,8 @@ depends 'dmg'
 depends 'windows'
 depends 'yum-epel'
 
-source_url 'https://github.com/jssjr/git'
-issues_url 'https://github.com/jssjr/git/issues'
+source_url 'https://github.com/jssjr/git' if respond_to?(:source_url)
+issues_url 'https://github.com/jssjr/git/issues' if respond_to?(:issues_url)
 
 attribute 'git/server/base_path',
           display_name: 'Git Daemon Base Path',


### PR DESCRIPTION
The new attributes introduced in Chef 12 are not backwards compatible. Using Berkshelf 3.1.1 will crash trying to resolve the cookbook with the error message saying that it cannot parse the metadata correctly. This fix is to add `if respond_to?(:source_url)` or something similar to maintain backwards compatibility. 