### PR TITLE
Added support for Solaris

### DIFF
--- a/libraries/provider_git_client_package.rb
+++ b/libraries/provider_git_client_package.rb
@@ -8,7 +8,7 @@ class Chef
 
         action :install do
           # FIXME: rhel 5
-          include_recipe 'yum-epel' if node['platform_version'].to_i == 5
+          include_recipe 'yum-epel' if node['platform_family'] == 'rhel' and node['platform_version'].to_i == 5
 
           # Software installation
           package "#{new_resource.name} :create #{parsed_package_name}" do

--- a/libraries/z_provider_mapping.rb
+++ b/libraries/z_provider_mapping.rb
@@ -10,5 +10,6 @@ Chef::Platform.set platform: :fedora, resource: :git_client, provider: Chef::Pro
 Chef::Platform.set platform: :redhat, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :scientific, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :smartos, resource: :git_client, provider: Chef::Provider::GitClient::Package
+Chef::Platform.set platform: :solaris2, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :suse, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :ubuntu, resource: :git_client, provider: Chef::Provider::GitClient::Package


### PR DESCRIPTION
On Solaris Git can be installed using the package resource, so I mapped the Package provider.

Ohai reports 5.9, 5.10 and 5.11 as platform version for Solaris 9, 10 and 11. So I had to adjust the condition to avoid the include for the EPEL recipe.