### PR TITLE
Suppress warning in chefspec with chef 12.4

### DIFF
--- a/libraries/provider_git_client_package.rb
+++ b/libraries/provider_git_client_package.rb
@@ -4,7 +4,7 @@ class Chef
       class Package < Chef::Provider::GitClient
         include Chef::DSL::IncludeRecipe
 
-        provides :git_client, os: 'linux' if respond_to?(:provides)
+        provides :git_client, os: 'linux', override: true if respond_to?(:provides)
 
         action :install do
           # FIXME: rhel 5

--- a/libraries/provider_git_client_source.rb
+++ b/libraries/provider_git_client_source.rb
@@ -4,7 +4,7 @@ class Chef
       class Source < Chef::Provider::GitClient
         include Chef::DSL::IncludeRecipe
 
-        provides :git_client, os: 'linux' if respond_to?(:provides)
+        provides :git_client, os: 'linux', override: true if respond_to?(:provides)
 
         action :install do
           return "#{node['platform']} is not supported by the #{cookbook_name}::#{recipe_name} recipe" if node['platform'] == 'windows'


### PR DESCRIPTION
This PR will suppress following warnings when running chefspec with chef 12.4:

```
WARN: You declared a new resource Chef::Provider::GitClient::Source for resource git_client, but it comes alphabetically after Chef::Provider::GitClient::Package and has the same filters ({:os=>"linux"}), so it will not be used. Use override: true if you want to use it for git_client.
```

```
WARN: You are overriding git_client on {:os=>"linux"} with Chef::Provider::GitClient::Package: used to be Chef::Provider::GitClient::Source. Use override: true if this is what you intended.
```

For information, from Chef12.4, it gives warning when you are replacing DSL provided by another resource or provider class:

```ruby
class X < Chef::Resource
  provides :file
end
class Y < Chef::Resource
  provides :file
end
```

This will emit a warning that Y is overriding X. To disable the warning, use override: true:

```ruby
class X < Chef::Resource
  provides :file
end
class Y < Chef::Resource
  provides :file, override: true
end
```

reference:
https://www.chef.io/blog/2015/06/24/chef-client-12-4-0-released/
