### PR TITLE
Repair RuboCop Rake task & address style rule failures

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'kitchen'
 # Style tests. Rubocop and Foodcritic
 namespace :style do
   desc 'Run Ruby style checks'
-  Rubocop::RakeTask.new(:ruby)
+  RuboCop::RakeTask.new(:ruby)
 
   desc 'Run Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef) do |t|

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@ when 'windows'
   default['git']['version'] = '1.9.5-preview20141217'
   default['git']['url'] = "https://github.com/msysgit/msysgit/releases/download/Git-#{node['git']['version']}/Git-#{node['git']['version']}.exe"
   default['git']['checksum'] = 'd7e78da2251a35acd14a932280689c57ff9499a474a448ae86e6c43b882692dd'
-  default['git']['display_name'] = "Git version #{ node['git']['version'] }"
+  default['git']['display_name'] = "Git version #{node['git']['version']}"
 when 'mac_os_x'
   default['git']['osx_dmg']['app_name']    = 'git-1.9.5-intel-universal-snow-leopard'
   default['git']['osx_dmg']['volumes_dir'] = 'Git 1.9.5 Snow Leopard Intel Universal'

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,5 +1,5 @@
 if defined?(ChefSpec)
-  def set_git_config(resource_name)
+  def set_git_config(resource_name) # rubocop:disable Style/AccessorMethodName
     ChefSpec::Matchers::ResourceMatcher.new(:git_config, :set, resource_name)
   end
 

--- a/libraries/provider_git_client_package.rb
+++ b/libraries/provider_git_client_package.rb
@@ -8,7 +8,7 @@ class Chef
 
         action :install do
           # FIXME: rhel 5
-          include_recipe 'yum-epel' if node['platform_family'] == 'rhel' and node['platform_version'].to_i == 5
+          include_recipe 'yum-epel' if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 5
 
           # Software installation
           package "#{new_resource.name} :create #{parsed_package_name}" do

--- a/libraries/provider_git_client_windows.rb
+++ b/libraries/provider_git_client_windows.rb
@@ -17,7 +17,7 @@ class Chef
           # Git is installed to Program Files (x86) on 64-bit machines and
           # 'Program Files' on 32-bit machines
           PROGRAM_FILES = ENV['ProgramFiles(x86)'] || ENV['ProgramFiles']
-          GIT_PATH = "#{ PROGRAM_FILES }\\Git\\Cmd"
+          GIT_PATH = "#{PROGRAM_FILES}\\Git\\Cmd"
 
           # COOK-3482 - windows_path resource doesn't change the current process
           # environment variables. Therefore, git won't actually be on the PATH

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -6,14 +6,14 @@ end
 
 action :set do
   if @current_resource.exists
-    Chef::Log.info "#{ @new_resource } already exists - nothing to do."
+    Chef::Log.info "#{@new_resource} already exists - nothing to do."
   else
     execute "#{config_cmd} #{new_resource.key} \"#{new_resource.value}\"" do
       cwd new_resource.path
       user new_resource.user
       group new_resource.user
       environment cmd_env
-      Chef::Log.info "#{ @new_resource } created."
+      Chef::Log.info "#{@new_resource} created."
     end
   end
 end

--- a/test/integration/default-windows/serverspec/git_installed_windows_spec.rb
+++ b/test/integration/default-windows/serverspec/git_installed_windows_spec.rb
@@ -5,7 +5,7 @@ set :os, family: 'windows'
 puts "os: #{os}"
 
 PROGRAM_FILES = ENV['ProgramFiles(x86)'] || ENV['ProgramFiles']
-GIT_PATH = "#{ PROGRAM_FILES }\\Git\\Cmd"
+GIT_PATH = "#{PROGRAM_FILES}\\Git\\Cmd"
 
 puts "PROGRAM_FILES: #{PROGRAM_FILES}"
 puts "GIT_PATH: #{GIT_PATH}"


### PR DESCRIPTION
This pull request brings the `rake style` task back to a passing/green state with current versions of RuboCop. Note that I didn't customize any RuboCop rules aside from skipping one in code. I believe this is one step to bring the Travis Ci state back to green. Thanks!!