### PR TITLE
[Bugfix] Add `mac_os_x` provider mapping.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,6 +27,14 @@ platforms:
 #   driver:
 #     box: chef/windows-server-2008r2-standard # private
 
+# - name: macosx-10.10
+#   driver:
+#     box: chef/macosx-10.10 # private
+
+# - name: macosx-10.9
+#   driver:
+#     box: chef/macosx-10.9 # private
+
 suites:
 - name: default
   run_list:

--- a/libraries/z_provider_mapping.rb
+++ b/libraries/z_provider_mapping.rb
@@ -7,6 +7,7 @@ Chef::Platform.set platform: :amazon, resource: :git_client, provider: Chef::Pro
 Chef::Platform.set platform: :centos, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :debian, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :fedora, resource: :git_client, provider: Chef::Provider::GitClient::Package
+Chef::Platform.set platform: :mac_os_x, resource: :git_client, provider: Chef::Provider::GitClient::Osx
 Chef::Platform.set platform: :redhat, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :scientific, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :smartos, resource: :git_client, provider: Chef::Provider::GitClient::Package


### PR DESCRIPTION
This commit restores support for Mac OS X 10.10 and Mac OS X 10.9, at a
minimum. Without this mapping, the following error is displayed:

```
No resource or method named `action_install' for `Chef::Provider::GitClient ""''
```