### PR TITLE
Fixes undefined method error on osx_dmg_source_url.

### DIFF
--- a/libraries/provider_git_client_osx.rb
+++ b/libraries/provider_git_client_osx.rb
@@ -11,7 +11,7 @@ class Chef
             app new_resource.osx_dmg_app_name
             package_id new_resource.osx_dmg_package_id
             volumes_dir new_resource.osx_dmg_volumes_dir
-            source new_resource.osx_dmg_source_url
+            source new_resource.osx_dmg_url
             checksum new_resource.osx_dmg_checksum
             type 'pkg'
             action :install


### PR DESCRIPTION
A typo in ab60eaa2b0b54a2145a035cec6612c069acd33f8 causes a NoMethodError to be thrown. This PR fixes the bug by accessing `osx_dmg_url` instead of `osx_dmg_source_url`.